### PR TITLE
Configure client auth API URL via env

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:5000
+envVITE_API_URL=http://localhost:5000

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -19,7 +19,10 @@ const Login = () => {
     setLoading(true);
 
     try {
-      const response = await axios.post('http://localhost:5000/api/auth/login', formData);
+      const response = await axios.post(
+        `${import.meta.env.VITE_API_URL}/api/auth/login`,
+        formData
+      );
       login(response.data.token, response.data.user);
       navigate('/dashboard');
     } catch (err) {

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -34,7 +34,7 @@ const Register = () => {
 
     setLoading(true);
     try {
-      const response = await axios.post('http://localhost:5000/api/auth/register', {
+      const response = await axios.post(`${import.meta.env.VITE_API_URL}/api/auth/register`, {
         email: formData.email,
         password: formData.password,
         firstName: formData.firstName,


### PR DESCRIPTION
## Summary
- add a Vite environment file for the client with the API base URL
- update the login and registration API calls to use the configured Vite environment variable

## Testing
- ⚠️ `npx prisma migrate dev --name init` *(fails: Can't reach database server at `localhost:5432`)*
- ✅ `npx prisma generate`
