### PR TITLE
Make local auth setup plug-and-play

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ RotateStay is a platform that helps medical students swap or rent housing during
    cd ../client && npm install
    ```
 
-2. Configure environment variables by copying `server/.env.example` to `.env` and providing real values.
+2. Configure environment variables by copying `server/.env.example` to `.env` and providing real values. If you are just
+   trying the project locally, the backend now falls back to safe development defaults (including a generated JWT secret) so
+   you can get started even if you skip this step.
 
 3. Run database migrations with Prisma once a PostgreSQL database is available:
 
@@ -73,7 +75,11 @@ RotateStay is a platform that helps medical students swap or rent housing during
    npm run migrate
    ```
 
-4. Start the backend and frontend development servers:
+4. (Optional) Toggle academic email requirements. By default development builds allow you to sign up with any email address
+   so you can explore the product quickly. Set `ALLOW_NON_EDU_EMAILS=false` in `server/.env` and
+   `VITE_REQUIRE_EDU_EMAIL=true` in `client/.env` if you want to enforce `.edu` addresses locally.
+
+5. Start the backend and frontend development servers:
 
    ```bash
    # Backend

--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:5000
+VITE_REQUIRE_EDU_EMAIL=false

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -8,6 +8,8 @@ import {
   ChatBubbleBottomCenterTextIcon
 } from '@heroicons/react/24/outline';
 
+const requireEduEmail = import.meta.env.VITE_REQUIRE_EDU_EMAIL !== 'false';
+
 const Landing = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-dark-900 via-dark-800 to-dark-900">
@@ -117,8 +119,10 @@ const Landing = () => {
 
 const features = [
   {
-    name: 'Verified Students Only',
-    description: 'All users verified with .edu emails and school IDs for maximum security.',
+    name: requireEduEmail ? 'Verified Students Only' : 'Built for Med Students',
+    description: requireEduEmail
+      ? 'All users verified with .edu emails and school IDs for maximum security.'
+      : 'Academic verification is optional in this environment so you can explore RotateStay instantly.',
     icon: ShieldCheckIcon
   },
   {
@@ -141,7 +145,9 @@ const features = [
 const steps = [
   {
     title: 'Sign Up & Verify',
-    description: 'Create your account with your .edu email and upload your school ID for verification.'
+    description: requireEduEmail
+      ? 'Create your account with your .edu email and upload your school ID for verification.'
+      : 'Create your account in seconds using any email while you try out RotateStay.'
   },
   {
     title: 'List or Search',

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -3,6 +3,8 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import axios from 'axios';
 
+const requireEduEmail = import.meta.env.VITE_REQUIRE_EDU_EMAIL !== 'false';
+
 const Login = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -60,7 +62,7 @@ const Login = () => {
               onChange={handleChange}
               required
               className="w-full px-4 py-2 bg-dark-700 border border-dark-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-primary-500 transition"
-              placeholder="john.doe@medical.edu"
+              placeholder={requireEduEmail ? 'john.doe@medical.edu' : 'john.doe@example.com'}
             />
           </div>
 

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -3,6 +3,9 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import axios from 'axios';
 
+const EDU_DOMAINS = ['.edu', '.ac.uk', '.edu.au', '.edu.ca'];
+const requireEduEmail = import.meta.env.VITE_REQUIRE_EDU_EMAIL !== 'false';
+
 const Register = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -27,9 +30,13 @@ const Register = () => {
       return;
     }
 
-    if (!formData.email.includes('.edu')) {
-      setError('Please use a valid .edu email address');
-      return;
+    if (requireEduEmail) {
+      const normalizedEmail = formData.email.toLowerCase().trim();
+      const hasEduDomain = EDU_DOMAINS.some((domain) => normalizedEmail.endsWith(domain));
+      if (!hasEduDomain) {
+        setError('Please use a valid academic email address');
+        return;
+      }
     }
 
     setLoading(true);
@@ -102,7 +109,7 @@ const Register = () => {
 
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-1">
-              Medical School Email (.edu required)
+              Email Address{requireEduEmail ? ' (.edu required)' : ''}
             </label>
             <input
               type="email"
@@ -111,7 +118,7 @@ const Register = () => {
               onChange={handleChange}
               required
               className="w-full px-4 py-2 bg-dark-700 border border-dark-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-primary-500 transition"
-              placeholder="john.doe@medical.edu"
+              placeholder={requireEduEmail ? 'john.doe@medical.edu' : 'john.doe@example.com'}
             />
           </div>
 

--- a/server/.env
+++ b/server/.env
@@ -2,3 +2,4 @@ DATABASE_URL="postgresql://postgres@localhost:5432/rotatestay"
 JWT_SECRET="super-secret-jwt-key-for-development-only-change-in-production"
 CLIENT_URL="http://localhost:5173"
 PORT=5000
+ALLOW_NON_EDU_EMAILS=true

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL="postgresql://username:password@localhost:5432/rotatestay"
 JWT_SECRET="your-super-secret-jwt-key-change-this"
 CLIENT_URL="http://localhost:5173"
+ALLOW_NON_EDU_EMAILS="true"
 
 SENDGRID_API_KEY="your-sendgrid-api-key"
 FROM_EMAIL="noreply@rotatestay.com"

--- a/server/src/config/env.js
+++ b/server/src/config/env.js
@@ -1,0 +1,37 @@
+import dotenv from 'dotenv';
+
+const result = dotenv.config();
+if (result.error && result.error.code !== 'ENOENT') {
+  throw result.error;
+}
+
+const nodeEnv = process.env.NODE_ENV || 'development';
+
+if (!process.env.JWT_SECRET) {
+  if (nodeEnv === 'production') {
+    throw new Error('JWT_SECRET must be set in the environment before starting the server.');
+  }
+
+  process.env.JWT_SECRET = 'rotate-stay-development-secret';
+  console.warn('\u26a0\ufe0f  No JWT_SECRET provided. Using a built-in development secret.');
+}
+
+if (!process.env.CLIENT_URL) {
+  process.env.CLIENT_URL = 'http://localhost:5173';
+}
+
+const allowNonEduEnv = process.env.ALLOW_NON_EDU_EMAILS;
+const allowNonEduEmails =
+  typeof allowNonEduEnv === 'string'
+    ? ['1', 'true', 'yes', 'on'].includes(allowNonEduEnv.toLowerCase())
+    : nodeEnv !== 'production';
+
+export const env = {
+  nodeEnv,
+  port: Number.parseInt(process.env.PORT ?? '5000', 10) || 5000,
+  clientUrl: process.env.CLIENT_URL,
+  jwtSecret: process.env.JWT_SECRET,
+  allowNonEduEmails,
+};
+
+export default env;

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import { PrismaClient } from '@prisma/client';
 import { sendVerificationEmail } from '../services/email.service.js';
 import { validateEduEmail } from '../utils/validation.js';
+import env from '../config/env.js';
 
 const prisma = new PrismaClient();
 
@@ -55,7 +56,7 @@ export const register = async (req, res) => {
 
     const token = jwt.sign(
       { id: user.id, email: user.email },
-      process.env.JWT_SECRET,
+      env.jwtSecret,
       { expiresIn: '7d' }
     );
 
@@ -90,7 +91,7 @@ export const login = async (req, res) => {
 
     const token = jwt.sign(
       { id: user.id, email: user.email },
-      process.env.JWT_SECRET,
+      env.jwtSecret,
       { expiresIn: '7d' }
     );
 

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import env from '../config/env.js';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
@@ -11,7 +12,7 @@ export const authenticate = async (req, res, next) => {
       throw new Error();
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, env.jwtSecret);
     const user = await prisma.user.findUnique({
       where: { id: decoded.id },
       select: {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -2,20 +2,18 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
-import dotenv from 'dotenv';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { fileURLToPath } from 'url';
-
-dotenv.config();
+import env from './config/env.js';
 
 const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {
-    origin: process.env.CLIENT_URL || 'http://localhost:5173',
+    origin: env.clientUrl,
     credentials: true
   }
 });
@@ -25,7 +23,7 @@ const __dirname = path.dirname(__filename);
 
 app.use(helmet());
 app.use(cors({
-  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  origin: env.clientUrl,
   credentials: true
 }));
 app.use(morgan('dev'));
@@ -56,7 +54,6 @@ app.use('/api/reviews', reviewRoutes);
 
 new ChatService(io);
 
-const PORT = process.env.PORT || 5000;
-httpServer.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+httpServer.listen(env.port, () => {
+  console.log(`Server running on port ${env.port}`);
 });

--- a/server/src/services/socket.service.js
+++ b/server/src/services/socket.service.js
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import crypto from 'crypto';
 import { fileURLToPath } from 'url';
+import env from '../config/env.js';
 
 const prisma = new PrismaClient();
 
@@ -38,7 +39,7 @@ export class ChatService {
           throw new Error('Authentication failed');
         }
 
-        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        const decoded = jwt.verify(token, env.jwtSecret);
         const user = await prisma.user.findUnique({
           where: { id: decoded.id },
           select: { id: true, firstName: true, lastName: true }

--- a/server/src/utils/validation.js
+++ b/server/src/utils/validation.js
@@ -1,6 +1,12 @@
+import env from '../config/env.js';
+
 const EDU_DOMAINS = ['.edu', '.ac.uk', '.edu.au', '.edu.ca'];
 
 export const validateEduEmail = (email = '') => {
+  if (env.allowNonEduEmails) {
+    return true;
+  }
+
   const normalized = email.toLowerCase().trim();
   return EDU_DOMAINS.some((domain) => normalized.endsWith(domain));
 };


### PR DESCRIPTION
## Summary
- add a shared environment config that supplies sane local defaults and exposes the JWT secret to the rest of the server
- allow bypassing .edu address validation in development and surface the toggle in both the backend and frontend
- refresh onboarding docs and defaults so developers can sign up and sign in without any manual secrets work

## Testing
- npm run build (client)